### PR TITLE
steps: the old Brewfile doesn't come over; disuse already decided it

### DIFF
--- a/steps/20-packages/apps.md
+++ b/steps/20-packages/apps.md
@@ -23,7 +23,29 @@ macOS but works fine over ssh, so it lives with the CLI tools, not here.
 - **Voxtype** — push-to-talk voice-to-text. **Linux only**; it has no macOS build, so there's
   nothing to install there. If I want the same thing on a Mac it'll be a different app, and
   that's a fresh decision rather than a translation of this line.
+- **OBS Studio** — screen recording. Omarchy ships it, so it's already here; that is not the
+  same as it being unwanted, and on a Mac nothing would install it.
 - **Iosevka, Nerd Font build** — the terminal font.
+
+**A package the platform already ships is still a package I want.** Omarchy's base manifest
+carries `obsidian`, `chromium` and `obs-studio`, so none of them appear in a diff of this
+machine against that manifest — and a list built from such a diff drops them silently. That's
+the delta thinking this step opens by warning against, and it's an easy trap because the
+delta *looks* right on the machine it was built on. The test is whether I want it on a fresh
+Mac, not whether it's missing here.
+
+**Chromium is the exception, and it isn't really an app.** Omarchy uses it as the fallback
+browser for web apps (`omarchy-launch-webapp`), the default in `mimeapps.list`, and the
+backing for picture-in-picture and part of the menu. Platform infrastructure that happens to
+be a browser, so it isn't a choice this list gets to make.
+
+**Not wanted, despite being installed:** Obsidian. Omarchy ships it and I don't use it.
+Written down because the *absence* of a decision already caused one — a login step got
+drafted for it on the assumption it was wanted. A negative earns a line here only when the
+positive was previously assumed; this is not the start of an inventory of everything Omarchy
+ships that I don't use. And nothing here *uninstalls* it: a step that removes an OS-shipped
+package is a fight re-fought on every update, so if I want it gone from a machine that's a
+one-off by hand.
 
 Installing Syncthing is not the same as running it: it ships a user service that is **not
 enabled by default**, and it's currently installed-but-disabled on `hookers-green`. Decide
@@ -36,8 +58,12 @@ genuinely different package — not a naming difference. Resolve which one I act
 when there's a Mac in front of us rather than guessing now.
 
 Everything else from the old Mac Brewfile — 62 casks including whole sections named "try"
-and "random silly ones" — is **not** in scope here. It goes through
-[#12](https://github.com/pvinis/setup/issues/12) one app at a time.
+and "random silly ones" — was walked in
+[#12](https://github.com/pvinis/setup/issues/12) and **does not come over**. Every
+cross-platform entry there had already been rejected by simply not being installed on this
+machine; what remains is macOS-only (`raycast`, `bartender`, `fantastical`, `arq`,
+`rectangle-pro`…) and can't be judged without a Mac in front of me, so it waits for one
+rather than being guessed at now.
 
 ## Omarchy / Arch
 

--- a/steps/20-packages/cli-tools.md
+++ b/steps/20-packages/cli-tools.md
@@ -44,11 +44,14 @@ From the system package manager:
 repeated here — it's the root of trust and has to land before anything that needs a secret.
 
 This list is a deliberate core, not an inventory of either machine. Growing it happens one
-package at a time, with a reason, via
-[#12](https://github.com/pvinis/setup/issues/12) — not by dumping `pacman -Qqe` or
-`brew leaves` into it. Several things on the old Mac list (`direnv`, `fish`, `thefuck`,
-`tree`, `wget`, `diff-so-fancy`) aren't here and aren't on this Linux box either; whether
-that's drift or a decision is that ticket's question, not this step's.
+package at a time, with a reason — not by dumping `pacman -Qqe` or `brew leaves` into it.
+
+Several things on the old Mac list (`direnv`, `fish`, `thefuck`, `tree`, `wget`,
+`diff-so-fancy`) aren't here and aren't on this Linux box either.
+[#12](https://github.com/pvinis/setup/issues/12) asked whether that was drift or a decision
+and settled it as a **decision**: I have been running this machine without them for its whole
+life, which is a stronger answer than anything I'd have reasoned out. Absence from this list
+is a verdict, not an oversight.
 
 ## Omarchy / Arch
 


### PR DESCRIPTION
Resolves #12.

The personal delta on `hookers-green` is **seven packages** and the steps already carried all seven. Of the old Brewfile's 99 entries, 15 were already stepped and **zero of the other 84 are installed here** — every cross-platform one had been rejected by simply never being reinstalled, which is a stronger answer than any reasoning. The ~55 macOS-only entries can't be judged without a Mac, so they stay in the archived repo behind a pointer (#11 is now constrained to archive, not delete).

Also fixes a defect the measurement turned up: **`apps.md` was reproducing the delta thinking it opens by warning against.** Omarchy's base manifest ships `obsidian`, `chromium` and `obs-studio`, so none appear in a diff against it — and the step's list *was* that diff. Run it on a Mac and you get no OBS.

- **OBS Studio added** — the one entry in all 99 passing the use test on both machines
- **Chromium ruled platform infrastructure** — it backs `omarchy-launch-webapp`, `mimeapps.list`, PiP and part of the menu; never a choice this list makes
- **Obsidian recorded as not wanted**, and struck from #21, which had drafted a login step purely because it was present

New rule, to stop negatives becoming a second inventory: record a "not wanted" **only where the positive was previously assumed**. And nothing uninstalls — a step that removes an OS-shipped package is a fight re-fought on every update.

Full reasoning in the [resolution on #12](https://github.com/pvinis/setup/issues/12#issuecomment-5361495640).

🤖 Generated with [Claude Code](https://claude.com/claude-code)