### PR TITLE
steps: personal git config moves out of Omarchy's shipped copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,10 @@ Steps live in `steps/`; the format they follow is [`steps/README.md`](steps/READ
 - [`appearance.md`](steps/30-desktop/appearance.md)
 - *input, bar, dock, sound, displays, idle and lock, terminal font* — [#19](https://github.com/pvinis/setup/issues/19)
 
-**`40-shell/`** — *shell config, git config*: [#20](https://github.com/pvinis/setup/issues/20)
+**`40-shell/`**
+
+- [`shell-config.md`](steps/40-shell/shell-config.md) — personal aliases and exports, below the platform's own line
+- [`git-config.md`](steps/40-shell/git-config.md) — the non-identity half of git config, and the `~/.gitconfig` seam
 
 ## Working on the repo
 
@@ -46,4 +49,4 @@ The five canonical triage roles, default label names unchanged. See `docs/agents
 
 ### Domain docs
 
-Single-context: `CONTEXT.md` and `docs/adr/` at the repo root. Neither exists yet; `/domain-modeling` creates them lazily. See `docs/agents/domain.md`.
+Single-context: [`CONTEXT.md`](CONTEXT.md) at the repo root — read it before writing a step, since it settles where a personal value is allowed to live on a platform someone else configured. `docs/adr/` doesn't exist yet; `/domain-modeling` creates it lazily. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,57 @@
+# Setup
+
+The runbook an agent works through on a fresh machine. The vocabulary here is about **where a
+value goes** on a platform someone else already configured — the question every step ends up
+asking, and the one that has been answered inconsistently until it was named.
+
+## Language
+
+### How a platform's config relates to mine
+
+Three shapes, and which one a file has decides where personal values are allowed to live.
+
+**Sourced layer**:
+The platform's file stays package-owned and mine *reads* it — `~/.bashrc` sourcing
+`$OMARCHY_PATH/default/bash/rc`. Updates flow through underneath; anything below the source
+line is untouched forever.
+_Avoid_: include, import
+
+**Override file**:
+A file the platform loads *after* its own defaults, existing to be written by me —
+`~/.config/hypr/looknfeel.lua`. The defaults stay where they are and I state only the delta.
+_Avoid_: user config, local config
+
+**Shipped copy**:
+The platform copies its file into my home once at install and can re-copy it over mine later
+— `~/.config/git/config`, replaced by `omarchy-refresh-config git/config`. It looks like
+mine and isn't: my edits are in the path of the next refresh, and the platform's improvements
+never reach a file I've touched.
+_Avoid_: default config, stock config (those name the *source*, not the copy)
+
+**The rule:** never put personal values in a shipped copy. Find or make a file the platform
+doesn't own — for git that's `~/.gitconfig`, which git reads alongside the copy and which
+wins.
+
+### Steps
+
+**Step**:
+One intent, spanning platforms, as a markdown file under `steps/`. Format in
+[`steps/README.md`](steps/README.md).
+_Avoid_: task, script, recipe
+
+**Ask**:
+A question the runbook puts to me because no platform fact predicts the answer — timezone,
+headed or headless. Not a step, and not human work.
+_Avoid_: prompt, input
+
+**Human step**:
+Work only I can do, end to end — a password, a second factor, a GUI login. Its own group,
+`steps/00-human/`, walked first. A human beat *inside* an otherwise agent-run step doesn't
+make it one.
+_Avoid_: manual step, interactive step
+
+**Desired state**:
+What I want present, stated without reference to what any one platform ships — so a step is
+free to be a no-op where the platform already provides it. The opposite of a delta against a
+particular machine.
+_Avoid_: manifest, delta, diff

--- a/steps/40-shell/git-config.md
+++ b/steps/40-shell/git-config.md
@@ -1,0 +1,131 @@
+# Git config
+
+The git behaviour I want: rebase on pull, upstream set on first push, diffs I can read,
+conflict resolutions remembered, `main` for new repos, and one alias of my own. Same
+desired-state idea as the package steps — state what I want, and let it be a no-op wherever
+the platform already provides it.
+
+**Identity is not this step.** Name, email, signing key and the credential helper belong to
+the chain of trust in [#5](https://github.com/pvinis/setup/issues/5). They land in the same
+file this step establishes, which is why the seam below is worth getting right first.
+
+Needs git, from [`../20-packages/cli-tools.md`](../20-packages/cli-tools.md).
+
+## The seam: `~/.gitconfig` is mine
+
+Git reads **two** user-level files — `~/.gitconfig` and `~/.config/git/config` — and
+`~/.gitconfig` wins on single-valued settings, while multi-valued ones like aliases merge
+across both. So personal values go in `~/.gitconfig`, whatever the platform ships stays
+where the platform put it, and neither has to know about the other.
+
+This is the same shape as [`shell-config.md`](shell-config.md) next door — mine layered over
+theirs — but it's arrived at the hard way, because git's platform file is a *copy* rather
+than something mine sources.
+
+**The trap:** with no `~/.gitconfig` present, `git config --global …` writes into
+`~/.config/git/config` instead. Creating the file is what redirects every later `--global`
+write; until it exists, the command that looks like it's editing your config is editing the
+platform's.
+
+The captured Mac used `~/.gitconfig` and this machine uses `~/.config/git/config`, which
+looked like a divergence to resolve. It isn't. They're two layers, and the personal one is
+`~/.gitconfig` on both.
+
+## What I want
+
+Written to `~/.gitconfig` on macOS; on Omarchy all but the first two arrive stock, so read
+them back rather than writing them again.
+
+| What I want | Setting |
+| --- | --- |
+| `main` for new repos | `init.defaultBranch = main` |
+| undo the last commit, keep the changes staged | `alias.boc = reset --soft HEAD~1` |
+| rebase on pull, never a merge bubble | `pull.rebase = true` |
+| upstream set for me on first push | `push.autoSetupRemote = true` |
+| diffs that survive moved code | `diff.algorithm = histogram`, `diff.colorMoved = plain`, `diff.mnemonicPrefix = true` |
+| the diff in front of me while writing the message | `commit.verbose = true` |
+| columns when the terminal has room | `column.ui = auto` |
+| branches newest-first, tags in version order | `branch.sort = -committerdate`, `tag.sort = -version:refname` |
+| conflict resolutions remembered and reapplied | `rerere.enabled = true`, `rerere.autoupdate = true` |
+| short aliases | `alias.co/br/ci/st` |
+
+`init.defaultBranch` is the one to watch. Omarchy ships `master`; that's *Omarchy's* default,
+not a preference of mine, and asserting `main` over it is most of what this step does on that
+platform.
+
+## Omarchy
+
+Omarchy ships `/usr/share/omarchy/config/git/config` and **copies** it to
+`~/.config/git/config` at install. Nothing sources anything, and
+`omarchy-refresh-config git/config` re-copies stock over your version (saving
+`.bak.<epoch>` beside it). So personal values written there sit in the path of the next
+refresh, and stock improvements never reach a file you've edited.
+
+The whole Omarchy job is therefore: put the two personal settings in `~/.gitconfig`, and
+leave the copy **exactly as shipped**.
+
+```sh
+git config --global init.defaultBranch main
+git config --global alias.boc 'reset --soft HEAD~1'
+```
+
+Both land in `~/.gitconfig` — but only once it exists, so create it first (an empty
+`touch ~/.gitconfig` is enough) or write the file directly. On a machine where `--global`
+has already been run without it, the values are in the copy and need moving out, not just
+setting.
+
+## macOS
+
+No platform layer at all: `~/.gitconfig` is simply *the* config, and it carries the whole
+table above rather than a delta. Nothing to leave alone, nothing that gets refreshed.
+
+Reasoned, not yet run on a Mac.
+
+## Per-client config
+
+Client-specific settings — a different email, a different signing key for one org's repos —
+go here rather than becoming a machine-level thing, because a client engagement starts and
+ends on a different clock than a machine does. The mechanism is `includeIf` keyed on the
+**remote URL**:
+
+```
+[includeIf "hasconfig:remote.*.url:https://github.com/SomeOrg/*"]
+	path = ~/.config/git/config-someorg
+```
+
+**Keyed on the remote, never on the hostname.** That's the durable part: it follows the
+repo, so it's right on every machine at once with nothing to render or parameterise, and it
+degrades cleanly — a machine without the included file just doesn't include it. An older
+attempt keyed the same idea on hostname through a chezmoi template, hardcoded two hosts with
+no else branch, and rendered *empty* on a third machine without saying so.
+
+No client block is asserted. There's no client on this machine, and writing one would be
+inventing state; this section is here so the next one has a shape to arrive into.
+
+## Knowing it's done
+
+```sh
+git config --get init.defaultBranch          # main
+git config --get-regexp '^alias\.'           # boc, plus whatever the platform ships
+```
+
+On Omarchy there's a second check, and it's the one that proves the seam holds:
+
+```sh
+diff ~/.config/git/config /usr/share/omarchy/config/git/config   # no output
+```
+
+Byte-identical to stock means `omarchy-refresh-config git/config` is a genuine no-op that
+can never cost anything. Any output is personal config that has drifted into the refreshable
+file.
+
+**The lie to watch for:** `git config --get` and `--list` report the *merged* result, so
+everything reads correct even when every value is piled in the file that gets overwritten.
+The check that can't be wrong names the file:
+
+```sh
+git config --list --show-origin | grep -E 'defaultbranch|alias\.boc'
+```
+
+Expect `init.defaultbranch` **twice** on Omarchy — `master` from the copy, then `main` from
+`~/.gitconfig`. Two lines is the layering working, not a conflict; the later file wins.

--- a/steps/40-shell/shell-config.md
+++ b/steps/40-shell/shell-config.md
@@ -1,0 +1,68 @@
+# Shell config
+
+Anything I add to my shell — aliases, exports, functions — lives **below** the line that
+loads the platform's own config, so an OS update never eats it. Today that's exactly one
+alias, and the thinness is the point: this step is here so the seam is ready and named, not
+because there's volume to manage.
+
+The alias points at `claude`, installed by [`../20-packages/cli-tools.md`](../20-packages/cli-tools.md).
+It doesn't need it to exist, so there's no ordering constraint — a dangling alias is
+harmless.
+
+## Omarchy (bash)
+
+`~/.bashrc` **sources** Omarchy's config rather than copying it:
+
+```sh
+source "$OMARCHY_PATH/default/bash/rc"
+```
+
+which in turn pulls in `envs`, `shell`, `aliases`, `functions`, `init` and an `inputrc`
+binding. Personal config goes after that line — Omarchy writes the invitation into the stock
+file itself (*"Add your own exports, aliases, and functions here"*), so this is recognising a
+seam the platform offers, not inventing one.
+
+That sourcing is also why the block is safe. `~/.bashrc` is **not** under
+`/usr/share/omarchy/config/`, so `omarchy-refresh-config` cannot reach it, and
+`omarchy-refresh-shell` is about `omarchy/shell.json` (the bar) despite the name. Updates
+flow through the sourced file underneath, leaving anything below the line alone. This is the
+opposite of [`git-config.md`](git-config.md) next door, where the platform's file is a
+*copy* and personal values in it are in the path of the next refresh — worth reading the two
+together once.
+
+Today's contents, in full:
+
+```sh
+alias ac='claude'
+```
+
+## macOS (fish)
+
+**Unwritten — waits for a Mac.** The Mac ran fish, and that config was never captured: not in
+[`reference/mac-snapshot-2026-06/`](../../reference/mac-snapshot-2026-06/) (its README says
+so outright), not in `setup2`, not anywhere. So there is no source material to write this
+from, and reconstructing it from memory would be inventing state.
+
+The shape to work out when a Mac appears: fish's own file is `~/.config/fish/config.fish`,
+and the question is whether anything platform-owned sits under it the way Omarchy's `rc`
+does — if nothing does, the seam is trivial and this section is two lines.
+
+The runbook does **not** assert a shell. Omarchy is bash and wired deep into it; the Mac was
+fish; each platform keeps what it has.
+
+## Knowing it's done
+
+Check the file and a fresh shell, because they can disagree in both directions — an alias
+typed at a prompt is real but unwritten, and one written to the file is absent from every
+shell already open:
+
+```sh
+grep -n 'default/bash/rc\|alias ac' ~/.bashrc   # the source line, then the alias, in that order
+bash -ic 'type ac'                              # ac is aliased to `claude'
+```
+
+The line numbers are the part that matters, and they're the reason to grep rather than just
+run `type`. `type ac` passes whether the alias sits above or below the source line — but
+above it, anything Omarchy defines under the same name overrides mine, and it does so
+silently, on an update I didn't make. Nothing collides today; the ordering is what keeps it
+that way.


### PR DESCRIPTION
Resolves #20.

The ticket expected `git-config.md` to be **a no-op on Omarchy** and to carry its real content only for macOS. Writing it turned up the reason that framing was wrong.

`~/.bashrc` **sources** Omarchy's config, so anything below that line survives updates forever. `~/.config/git/config` is a **copy** Omarchy made at install and can re-copy over (`omarchy-refresh-config git/config`), so personal values in it sit in the path of the next refresh. And the sharp bit: **with no `~/.gitconfig` present, every `git config --global` writes straight into that copy** — which is what has been happening on this machine.

So there is real work here, and it's a seam: `~/.gitconfig` is a file Omarchy doesn't ship, git reads it *alongside* the copy, and it wins on single-valued settings while aliases merge. Personal values go there on **both** platforms, which collapses the snapshot README's "git config path divergence" (Mac `~/.gitconfig` vs Omarchy `~/.config/git/config`) into two layers with one answer.

That buys a check you can't be wrong about: `diff ~/.config/git/config /usr/share/omarchy/config/git/config` returning nothing means a refresh is a genuine no-op that can never cost anything. Applied and green on `hookers-green`.

**Decisions in the step**

- **`main`, over Omarchy's `master`** — that's Omarchy's default, never a preference of mine
- **`boc` kept**, against the disuse rule that would have dropped it
- **Identity is still #5's.** Its `[user]` and `[credential]` blocks move to `~/.gitconfig` verbatim — hardcoded `gh` mise path and all — for #5 to fix, because the seam isn't real while identity sits in the refreshable file
- **Per-client config gets its mechanism documented, no client block asserted** — `includeIf` keyed on the *remote URL*, so it follows the repo rather than the machine
- **The runbook asserts no shell.** Omarchy is bash; the Mac was fish and that config was never captured anywhere, so the macOS section says so instead of inventing it
- **The global gitignore stays out** — an ordered list of patterns is exactly "the value *is* the file"

`CONTEXT.md` gets its first entries: **sourced layer**, **override file**, **shipped copy** — the three shapes this repo keeps meeting under different names — plus the rule that personal values never go in the third.

Full reasoning in the resolution on #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
