### PR TITLE
context: name the machine file, and what it's allowed to hold

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,8 +41,16 @@ _Avoid_: task, script, recipe
 
 **Ask**:
 A question the runbook puts to me because no platform fact predicts the answer — timezone,
-headed or headless. Not a step, and not human work.
+headed or headless. Not a step, and not human work; its answer is remembered in the machine
+file.
 _Avoid_: prompt, input
+
+**Machine file**:
+`~/THIS-MACHINE.md` — the answers to this machine's asks, plus a newest-first log of what
+each run changed. Lives in `$HOME` because it describes the machine and not the repo, and is
+never committed. Holds answers only: a value a step can derive is recomputed every run, never
+stored.
+_Avoid_: state file, cache, manifest, machine config
 
 **Human step**:
 Work only I can do, end to end — a password, a second factor, a GUI login. Its own group,


### PR DESCRIPTION
Resolves [Where does a machine's answers live between runs?](https://github.com/pvinis/setup/issues/13). The full answer is the [resolution comment](https://github.com/pvinis/setup/issues/13#issuecomment-5364369692); this is the only repo change it produced.

`~/THIS-MACHINE.md` was decided in [#7](https://github.com/pvinis/setup/issues/7) and is already referenced by `steps/10-system/hostname.md`, but had never been named in the glossary. #13 settled what it is allowed to hold — **the answers to asks, and nothing else** — which is what dissolves the "per-step results" category that ticket was opened to find a home for: a value a step can derive is recomputed every run rather than stored, and a value that can't be stated in a sentence was never a step.

`Ask` gains one clause saying where its answer goes, since an answer with nowhere to live was the actual gap.

Nothing else changes. The rules for *writing* the file belong to [Write AGENTS.md as the runbook entry, not just repo notes](https://github.com/pvinis/setup/issues/22), and `~/THIS-MACHINE.md` is deliberately not created on `hookers-green` yet — a file written before its rules is a file that disagrees with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)