### PR TITLE
steps: the rest of the desktop group; three of its values were already stock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,13 @@ Steps live in `steps/`; the format they follow is [`steps/README.md`](steps/READ
 
 - [`cursor-size.md`](steps/30-desktop/cursor-size.md)
 - [`appearance.md`](steps/30-desktop/appearance.md)
-- *input, bar, dock, sound, displays, idle and lock, terminal font* — [#19](https://github.com/pvinis/setup/issues/19)
+- [`input.md`](steps/30-desktop/input.md) — tap to click, traditional scroll direction
+- [`displays.md`](steps/30-desktop/displays.md) — scaling; asks rather than asserts
+- [`terminal-font.md`](steps/30-desktop/terminal-font.md) — Iosevka, and the one knob that sizes all text
+- [`bar.md`](steps/30-desktop/bar.md) — position, clock format, battery percentage
+- [`idle-and-lock.md`](steps/30-desktop/idle-and-lock.md) — macOS values not captured yet
+- [`dock.md`](steps/30-desktop/dock.md) — macOS only
+- [`sound.md`](steps/30-desktop/sound.md) — macOS only
 
 **`40-shell/`**
 

--- a/steps/30-desktop/bar.md
+++ b/steps/30-desktop/bar.md
@@ -1,0 +1,93 @@
+# Bar
+
+The status bar along the **top**, carrying a clock I can read without stopping to parse it —
+weekday and 24-hour time — plus, on a laptop, the battery as a **number** rather than a
+picture of a battery.
+
+What's *on* the bar isn't part of this. An ordered list of widgets is the value being the
+file, which [`README.md`](../README.md) rules out of a step; this machine has three
+third-party widgets in that list and the runbook deliberately doesn't know about them.
+
+## macOS
+
+| What I want | System Settings | Command |
+| --- | --- | --- |
+| Clock shows weekday, date, 24h time | Control Centre > Clock Options / Date & Time | `defaults write com.apple.menuextra.clock DateFormat -string "EEE d MMM  HH:mm"` |
+| Battery percentage | Control Centre > Battery > Show percentage | `defaults write com.apple.menuextra.battery ShowPercent -boolean YES` |
+
+**Two spaces before the time** in that format string, between `MMM` and `HH` — it's the
+visual gap between date and time in the menu bar, not a typo to tidy up.
+
+**Applying it now** is `killall SystemUIServer`, not `killall Dock`: the menu bar extras
+live in that process and won't re-read either key until it restarts. The bar blinks out and
+comes back within a second.
+
+The battery key is inert on a desktop Mac with no battery. It's still worth writing — same
+reasoning as the Magic Trackpad domain in [`input.md`](input.md).
+
+## Omarchy (Hyprland)
+
+| What I want | Where | Command |
+| --- | --- | --- |
+| Bar at the top | `~/.config/omarchy/shell.json`, `bar.position` | `omarchy bar position top` |
+| Clock: weekday + 24h time | same file, the `omarchy.clock` widget | `omarchy bar set omarchy.clock format "dddd HH:mm"` |
+
+Battery has no row: the Omarchy bar's power widget shows a percentage already, with nothing
+to turn on.
+
+**Both of these are already Omarchy's stock values**, so this section is a no-op on a fresh
+install — which is the point of stating desired state rather than a delta. Run the commands
+anyway; they're what makes the step true on a platform whose defaults move.
+
+They're idempotent in **value** but not in **bytes**: each one pipes the whole file through a
+normalising `jq` pass that sorts keys alphabetically, so running them on an already-correct
+machine rewrites `shell.json` top to bottom and any byte-level comparison lights up. Nothing
+changed — compare with `jq -S` on both sides, as the check below does, and it comes back
+empty.
+
+**Use the commands, don't hand-edit the file.** `~/.config/omarchy/shell.json` is a **shipped
+copy** in the sense [`CONTEXT.md`](../../CONTEXT.md) gives the word — Omarchy copies it into
+`~/.config` at install *with its full default contents*, and `omarchy refresh shell` copies
+stock straight back over it. So a personal value written there is sitting in the path of the
+next refresh, and there is **no override layer for it**: `~/.config/omarchy/shell.toml` is a
+real override file (see [`terminal-font.md`](terminal-font.md)) but it only carries styling
+tokens — font, spacing, colours — and cannot express bar position or a clock format.
+
+The saving grace is that both values here *equal* stock, which buys the same check
+`git-config.md` gets: if the diff against stock is empty, a refresh can never cost anything.
+
+```sh
+diff <(jq -S . ~/.config/omarchy/shell.json) \
+     <(jq -S . /usr/share/omarchy/config/omarchy/shell.json)
+```
+
+On this machine that prints only the three extra widgets — the part that isn't a step
+anyway. The day it prints a `position` or `format` line, this step has started carrying a
+value a refresh would eat, and that's worth knowing before the refresh rather than after.
+
+## Knowing it's done
+
+**macOS.** Read the keys back:
+
+```sh
+defaults read com.apple.menuextra.clock DateFormat     # EEE d MMM  HH:mm
+defaults read com.apple.menuextra.battery ShowPercent  # 1
+```
+
+Missing keys are the never-ran state: stock is time-only with no weekday, and no battery
+percentage. Both `defaults read` calls exit non-zero there, which is the correct reading of
+"still stock", not a failed check.
+
+**Omarchy.** The shell watches `shell.json` and hot-reloads on save, so for once the file
+and the running bar can't drift — reading the file is honest:
+
+```sh
+jq -r '.bar.position' ~/.config/omarchy/shell.json                              # top
+jq -r '.bar.layout.center[] | select(.id=="omarchy.clock") | .format' \
+  ~/.config/omarchy/shell.json                                                  # dddd HH:mm
+```
+
+Then look at the bar. The one way this check lies is a bar the shell failed to start at all:
+the file reads perfectly and there's nothing on screen. The shell is a plain Quickshell
+process started by the Hyprland session rather than a systemd unit, so
+`pgrep -f 'quickshell.*omarchy'` is the confirmation — or just seeing the clock.

--- a/steps/30-desktop/displays.md
+++ b/steps/30-desktop/displays.md
@@ -1,0 +1,117 @@
+# Displays
+
+Everything on screen at a size I can actually read, which is the one setting in this group
+with **no right answer to write down**. A 1920×1080 laptop panel and a 4K external want
+opposite numbers, so this step *asks* rather than asserting — same reasoning that keeps
+[`cursor-size.md`](cursor-size.md) from freezing `36`, except here even the derivation is
+per-machine.
+
+Two things this step deliberately doesn't own. The **arrangement** — which panel sits at
+which position, at which resolution — is the value being the file, so it's out of scope and
+stays hand-done. And **apparent text size** is a different knob with its own step: on
+Omarchy that's `omarchy display text size`, which [`terminal-font.md`](terminal-font.md)
+owns. Reach for that one first; scaling is the blunter instrument and it moves everything,
+including things that were already the right size.
+
+## The asks
+
+Two questions, both per-machine, neither predicted by any platform fact:
+
+- **How should this display be scaled?** Ask when there's any doubt. `1` is right for a
+  1920×1080 panel; a HiDPI panel usually wants `2`, and the awkward middle wants a
+  fractional value that costs sharpness in XWayland apps.
+- **Which display is primary?** Only a question when there's more than one. There's a single
+  built-in panel on `hookers-green`, so it goes unasked here and the answer is unrecorded —
+  which is the correct state for an ask nobody has needed yet, not a gap.
+
+Answers live in `~/THIS-MACHINE.md` like every other ask, and get shown back in the plan on
+a re-run rather than asked again.
+
+## Omarchy (Hyprland)
+
+Two values, in `~/.config/hypr/monitors.lua`, and they are **not** the same knob:
+
+```lua
+local omarchy_gdk_scale = 1
+local omarchy_monitor_scale = 1
+```
+
+- `omarchy_monitor_scale` is the **compositor's** scale, handed to `hl.monitor`. It's what
+  makes Wayland clients draw bigger.
+- `omarchy_gdk_scale` is exported as the `GDK_SCALE` **environment variable**, which is how
+  GTK apps that aren't scaling themselves — and XWayland — find out.
+
+Stock is `2` and `"auto"`. This machine runs `1` and `1`: the built-in panel is 1920×1080,
+and a scale of 2 would leave it drawing an effective 960×540. Read the stock values before
+assuming, the way the cursor step does — Omarchy owns that file and an update can move them.
+
+### This is the one hypr file where the defaults live in *my* copy
+
+Worth a paragraph, because it inverts what the neighbouring steps rely on.
+`~/.config/hypr/looknfeel.lua` and `input.lua` arrive as **all-commented templates**: the
+real defaults sit in `/usr/share/omarchy/default/hypr/`, loaded first, and my file only ever
+holds the delta. `omarchy refresh config` on one of those costs me my overrides and nothing
+else.
+
+`monitors.lua` has **no counterpart in `default/hypr/`**. The shipped copy carries live,
+uncommented values and the `hl.env`/`hl.monitor` calls themselves — so it's a **shipped
+copy** in [`CONTEXT.md`](../../CONTEXT.md)'s sense, and
+`omarchy refresh config hypr/monitors.lua` silently restores `2` / `"auto"`. There's nowhere
+else to put the scale, so this is a case of editing the copy knowingly rather than a seam to
+find. Check the file after any refresh.
+
+### `GDK_SCALE` is inert until the next login
+
+Exactly the trap [`cursor-size.md`](cursor-size.md) documents, for exactly the same reason:
+`hl.env` is applied by Hyprland at startup, and UWSM exports the variable into the systemd
+and dbus environments once, at login. **`hyprctl reload` returns `ok` and does not move
+it.** The compositor scale *does* reload — so a half-applied state is the normal outcome of
+editing this file, with windows resized and GTK apps still scaling the old way.
+
+Either log out and back in, or push it into the running session too:
+
+```sh
+systemctl --user set-environment GDK_SCALE=1
+dbus-update-activation-environment --systemd GDK_SCALE=1
+```
+
+Pass the value explicitly, never the bare name — given `GDK_SCALE` alone,
+`dbus-update-activation-environment` reads it from the calling shell, and a shell older than
+the change writes the stale value straight back.
+
+Apps already running keep the scale they launched with regardless; only new windows pick it
+up.
+
+For a one-off nudge without touching the file at all — trying a value before committing to
+it — `omarchy hyprland monitor scaling <scale>` moves the focused monitor for this session
+only.
+
+## macOS
+
+Scaling is a **resolution preset**, not a number: System Settings > Displays, the row of
+"Larger Text … More Space" options. There's no stable `defaults` key worth writing — the
+per-display preference is an opaque blob keyed by display UUID, which is precisely the "the
+value *is* the file" case.
+
+So on macOS this step is entirely its ask: pick the preset, and record the answer. Nothing
+to apply, nothing to verify by command.
+
+Not yet run on a Mac.
+
+## Knowing it's done
+
+**Omarchy.** Ask the compositor for the scale, and the session — not the shell — for the
+environment variable:
+
+```sh
+hyprctl monitors | grep -E '^Monitor|scale:'      # scale: 1
+systemctl --user show-environment | grep GDK_SCALE # GDK_SCALE=1
+```
+
+`printenv GDK_SCALE` is the wrong check for the same reason it's wrong next door: it reports
+whatever the current shell inherited, so it shows the old value after a successful change
+and the new one after a failed change.
+
+The partial state is what to catch: `hyprctl monitors` reporting the new scale while
+`show-environment` still holds the old `GDK_SCALE`. That's the file written and reloaded but
+never logged out of, and it looks fine until a GTK app opens at the wrong size.

--- a/steps/30-desktop/dock.md
+++ b/steps/30-desktop/dock.md
@@ -1,0 +1,59 @@
+# Dock
+
+A small dock, out of the way on the **right** edge, and the top-right corner of the screen
+throws every window aside to show the desktop.
+
+**macOS only.** Omarchy has no dock and nothing playing the part of one — Hyprland's
+workspaces are how I get between windows there, and there's no surface to shrink or move.
+The single `##` section below *is* the applicability declaration; there's nothing missing
+here.
+
+## macOS
+
+| What I want | System Settings | Command |
+| --- | --- | --- |
+| Dock size 24 | Desktop & Dock > Size | `defaults write com.apple.dock tilesize -int 24` |
+| Dock on the right | Desktop & Dock > Position on screen | `defaults write com.apple.dock orientation -string right` |
+| Top-right corner → Desktop | Desktop & Dock > Hot Corners… | `defaults write com.apple.dock wvous-tr-corner -int 4` |
+| …with no modifier key held | (same sheet) | `defaults write com.apple.dock wvous-tr-modifier -int 0` |
+
+**Hot corners are in the dock's domain even though the GUI files them elsewhere** — they sit
+under Mission Control in older macOS and behind a button in Desktop & Dock now, but every
+one of them is a `com.apple.dock` key. That's why they're in this step and not a step of
+their own: same domain, same `killall`, one intent's worth of clicking.
+
+`wvous-tr-corner` is an enum, and **`4` is "Desktop"**, not a size or an index — the numbers
+are not guessable, so change it in the GUI and diff `defaults read` if a different action is
+ever wanted. `wvous-tr-modifier 0` means the corner fires on hover alone; a non-zero value
+there is a modifier-key bitmask, and leaving it unset is *not* the same as zero — an
+unwritten modifier can leave the corner armed but inert.
+
+**Applying it now**: `killall Dock`. The dock relaunches immediately and reads all four keys
+on the way up. Size and position are visible instantly; the hot corner needs the pointer
+taken to the corner to confirm.
+
+`tilesize` is the *resting* size. If dock magnification is ever turned on, the icons still
+grow past 24 on hover — that's `largesize` and a separate setting this step doesn't touch.
+
+## Knowing it's done
+
+```sh
+defaults read com.apple.dock tilesize        # 24
+defaults read com.apple.dock orientation     # right
+defaults read com.apple.dock wvous-tr-corner # 4
+defaults read com.apple.dock wvous-tr-modifier # 0
+```
+
+Never-ran states make `defaults read` exit non-zero rather than print a default, so a
+missing key here reads as "still stock" and not as a broken check: stock `orientation` is
+`bottom`, stock `tilesize` is larger than 24 (the exact number has moved between releases,
+so read it rather than expecting one), and both `wvous-tr` keys are simply absent, meaning
+no hot corner is assigned.
+
+The check that can lie is `orientation`: the dock also moves if it's dragged by its divider,
+and that writes the same key — so a correct reading always matches the screen. It's the
+opposite case to watch for, a key written while the Dock was never restarted, which
+`killall Dock` settles.
+
+The four values are captured — they come from the Mac, via `scripts/macos.sh` in
+`pvinis/dotfiles`. The notes around them are reasoned and haven't been re-run on a Mac.

--- a/steps/30-desktop/idle-and-lock.md
+++ b/steps/30-desktop/idle-and-lock.md
@@ -1,0 +1,70 @@
+# Idle and lock
+
+Leave the machine alone and the screensaver comes up at **2½ minutes**; leave it another 2½
+and it **locks**, at 5 minutes total. Two numbers, and the gap between them is the point —
+the screensaver is the warning that the lock is coming, so it has to land first and with
+enough room to notice.
+
+## Omarchy (Hyprland)
+
+Both live in `~/.config/omarchy/shell.json`, in seconds since idle began:
+
+```json
+"idle": {
+  "screensaver": 150,
+  "lock": 300
+}
+```
+
+**Both are Omarchy's stock values**, so this is a no-op on a fresh install — stated as
+desired state anyway, because the numbers are what I want and not merely what I was given.
+
+There's **no `omarchy` command for the timings**, unlike the bar next door: `omarchy bar
+position` and `omarchy bar set` cover their half of this file, but idle is a hand-edit, and
+that's what the shell's own docs prescribe. `omarchy toggle idle` looks like the CLI for
+this and isn't — see below.
+
+The same shipped-copy caveat applies as in [`bar.md`](bar.md): `shell.json` is copied into
+`~/.config` with its full default contents and `omarchy refresh shell` copies stock back over
+it, with no override layer able to express these keys. Because both values equal stock, a
+refresh currently costs nothing here — the diff in `bar.md` is the check that stays true.
+
+The shell watches the file and hot-reloads on save, so there's nothing to restart and no
+window where the file and the running session disagree.
+
+## macOS
+
+Applies, but **the values aren't captured**. The Mac these were photographed from is gone,
+`scripts/macos.sh` in `pvinis/dotfiles` never covered idle or lock, and the modern keys moved
+out from under `com.apple.screensaver` into System Settings > Lock Screen — so writing
+commands here would mean inventing them and calling reasoning a capture.
+
+This section exists to say the step *does* apply on macOS. When there's a Mac in front of
+me, capture it the way [`appearance.md`](appearance.md) describes: `defaults read > a`,
+change "Start Screen Saver when inactive" and "Require password after screen saver begins"
+in the GUI, `defaults read > b`, `diff a b`. Then the two rows land here and this paragraph
+goes away. Tracked with the other Mac-blocked items in the map's fog.
+
+## Knowing it's done
+
+**Omarchy.** The file is honest, because the shell hot-reloads it:
+
+```sh
+jq '.idle' ~/.config/omarchy/shell.json    # { "screensaver": 150, "lock": 300 }
+```
+
+**The way this check lies is worth more than the check.** `omarchy toggle idle` flips a
+stay-awake override that lives entirely outside this file — it drops a marker at
+`~/.local/state/omarchy/indicators/stay-awake` — and while that marker exists the timings
+above are correct and *nothing idles at all*. A machine left deliberately awake for a long
+build reads as perfectly configured and never locks. So check both:
+
+```sh
+omarchy toggle idle status    # {"enabled":false,...} — false means idle behaves normally
+```
+
+`enabled: true` there means stay-awake is on, which is the opposite of what the word
+suggests at a glance. Confirm properly by leaving the machine alone and watching, or accept
+the two readings together.
+
+**macOS.** Nothing to check until the values above exist.

--- a/steps/30-desktop/input.md
+++ b/steps/30-desktop/input.md
@@ -1,0 +1,88 @@
+# Input
+
+Tap to click, and scrolling in the traditional direction — two fingers down scrolls *down*
+the page — rather than the "natural" direction macOS ships. Both are trackpad habits I
+notice within about ten seconds of using a machine that has them the other way.
+
+## macOS
+
+| What I want | System Settings | Command |
+| --- | --- | --- |
+| Tap to click | Trackpad > Point & Click > Tap to click | `defaults write com.apple.AppleMultitouchTrackpad Clicking -int 1` |
+| …same, for a Magic Trackpad | (same pane, external device) | `defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -int 1` |
+| Scrolling not "natural" | Trackpad > Scroll & Zoom > Natural scrolling **off** | `defaults write -g com.apple.swipescrolldirection -int 0` |
+
+**Two domains for one setting.** `AppleMultitouchTrackpad` is the built-in trackpad;
+`driver.AppleBluetoothMultitouch.trackpad` is a Magic Trackpad paired over Bluetooth. The
+GUI shows one checkbox and writes whichever domain matches the device in front of it, so
+writing only one leaves the other device tapping-disabled the first time it connects. Write
+both, on every machine — the desktop that has no built-in trackpad today may get one paired
+tomorrow, and the key costs nothing where no such device exists.
+
+Log out and back in. These are read at login by the window server; unlike the appearance
+keys there's no `killall` that reliably re-reads them.
+
+## Omarchy (Hyprland)
+
+**Both are already true, and neither is Omarchy's doing in the way you'd guess.** Nothing to
+write — but the reason matters more than the no-op, because the obvious way to check is
+wrong:
+
+- `natural_scroll = false` is set explicitly in Omarchy's own defaults
+  (`/usr/share/omarchy/default/hypr/input.lua`).
+- `tap-to-click` is **Hyprland's** default. Nobody sets it — not Omarchy, not me — and it's
+  been `true` the whole time.
+
+So `~/.config/hypr/input.lua` here is byte-identical to the shipped template: every line
+commented out. **Diffing my config against Omarchy's shows nothing, and concluding "this
+isn't configured" would be wrong** — the intent is satisfied, just not by any file of mine.
+That's the whole reason this section exists rather than being left out.
+
+If a future machine wants either flipped, the override goes in `~/.config/hypr/input.lua`,
+which `hyprland.lua` requires *after* Omarchy's defaults:
+
+```lua
+hl.config({
+  input = {
+    touchpad = {
+      natural_scroll = false,
+    },
+  },
+})
+```
+
+These are plain config values, not environment variables, so `hyprctl reload` applies them
+— no logout, unlike [`cursor-size.md`](cursor-size.md) next door.
+
+## Knowing it's done
+
+**macOS.** Read all three keys back; `1`, `1`, `0`:
+
+```sh
+defaults read com.apple.AppleMultitouchTrackpad Clicking
+defaults read com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking
+defaults read -g com.apple.swipescrolldirection
+```
+
+A missing key is the never-ran state, not an error: stock macOS is tap-to-click **off** and
+natural scrolling **on**, so absent means "still at the default I don't want".
+
+**Omarchy.** Ask the compositor, never the file — the file is empty here even though the
+settings are right:
+
+```sh
+hyprctl getoption input:touchpad:tap-to-click     # bool: true    / set: false
+hyprctl getoption input:touchpad:natural_scroll   # bool: false   / set: true
+```
+
+**`getoption` prints a second line, `set:`, and it's the interesting one.** It says whether
+anything configured the value or whether it's Hyprland's built-in default. Those two lines
+above are the whole story of this section in four words: tap-to-click is `set: false`, a
+default nobody wrote, and `natural_scroll` is `set: true`, written by Omarchy. Both land on
+the value I want, by different routes — and only `set:` tells them apart.
+
+Which also means **`set: false` is not a failure here**. On a machine where the intent were
+*not* already the default, it would be.
+
+`input:natural_scroll` (no `touchpad:`) is the *mouse* setting and is a separate knob; it's
+also `false` here, which is the same intent for a device I don't use.

--- a/steps/30-desktop/sound.md
+++ b/steps/30-desktop/sound.md
@@ -1,0 +1,51 @@
+# Sound
+
+The alert sound is **Funk**, at **half volume** — audible enough to notice, quiet enough not
+to make me jump when a dialog appears while music is playing. Alert volume is its own level,
+independent of the output volume, which is why it can be pinned like this at all.
+
+**macOS only.** Not because Linux is silent, but because there's no equivalent *value* to
+state: Omarchy exposes no single alert-sound knob, its stock terminal configs already
+silence the bell (`enable_audio_bell no`), and the freedesktop sound theme underneath is a
+directory of oga files rather than a setting. Nothing here would be a sentence I could
+check, so — by the values-not-files rule in [`README.md`](../README.md) — there's no Omarchy
+section to write.
+
+## macOS
+
+| What I want | System Settings | Command |
+| --- | --- | --- |
+| Alert sound: Funk | Sound > Sound Effects > Alert sound | `defaults write -g com.apple.sound.beep.sound -string "/System/Library/Sounds/Funk.aiff"` |
+| Alert volume 0.5 | Sound > Sound Effects > Alert volume | `defaults write -g com.apple.sound.beep.volume -float 0.5` |
+
+**The sound is a path, not a name.** The GUI shows "Funk" in a list; the key holds
+`/System/Library/Sounds/Funk.aiff`. Writing the bare string `Funk` sets a value macOS won't
+resolve and the alert falls back to silence — a failure that looks exactly like a volume of
+zero. A custom sound dropped in `~/Library/Sounds` is the same key with a different path.
+
+**Half is 0.5 on a 0–1 float**, not a 0–100 percentage. It's also not the output volume:
+turning the speakers up doesn't move this, and muting the alert here leaves music playing.
+
+**Applying it now**: log out, or relaunch the app you want it in. Both keys live in
+`NSGlobalDomain`, which apps read at launch, so already-running apps keep the old alert
+until they restart. There's no `killall` that covers this the way `killall Dock` covers
+[`dock.md`](dock.md).
+
+## Knowing it's done
+
+```sh
+defaults read -g com.apple.sound.beep.sound   # /System/Library/Sounds/Funk.aiff
+defaults read -g com.apple.sound.beep.volume  # 0.5
+```
+
+Both keys are **absent on a stock machine**, whose alert sound is whatever macOS ships as
+the default that release, at full alert volume — so `defaults read` exiting non-zero is the
+never-ran state and reads as "still stock".
+
+The way this check lies: it reads the stored preference, not what you'd hear. An alert
+volume of 0.5 sounds like nothing at all if the output device is muted or the alert-sound
+file has been replaced with a path that doesn't exist. The honest confirmation is to trigger
+a beep and listen.
+
+Both values are captured from the Mac via `scripts/macos.sh` in `pvinis/dotfiles`; the notes
+around them are reasoned and not re-run on a Mac.

--- a/steps/30-desktop/terminal-font.md
+++ b/steps/30-desktop/terminal-font.md
@@ -1,0 +1,169 @@
+# Terminal font
+
+Iosevka in the terminal, at a size that's comfortable on this panel. One intent, and the
+most spread-out step in the group: **four config files, two font families, and a size that
+isn't a terminal setting at all.**
+
+**Prerequisite: the font has to be installed.** That's [`apps.md`](../20-packages/apps.md)'s
+job — `ttf-iosevka-nerd` on Arch — and it's where the plain-vs-Nerd-Font package divergence
+is already written down. Every value below is a family *name*: nothing here installs
+anything, and a name that doesn't resolve fails silently, falling back to whatever
+fontconfig picks next rather than erroring.
+
+Colours are not part of this. Each terminal config *imports* the theme file that
+[`appearance.md`](appearance.md) switches, so the two steps own different lines of the same
+file and never collide.
+
+## Two families, on purpose
+
+The Nerd Font patcher ships three widths of Iosevka and I use two of them:
+
+- **`Iosevka Nerd Font Mono`** — single-cell metrics. This is what every terminal pins by
+  name, because a terminal grid wants every glyph one cell wide.
+- **`Iosevka Nerd Font`** — the dual-width build. This is what the generic **`monospace`**
+  alias resolves to, so the Omarchy bar, Qt apps and anything else asking for "monospace"
+  get full-size wifi and volume glyphs instead of icons squeezed into one cell.
+
+That split lives in `~/.config/fontconfig/fonts.conf` — a genuine **override file**,
+loaded after the package-owned default, and one Omarchy never copies over:
+
+```xml
+<match target="pattern">
+  <test name="family" qual="any"><string>monospace</string></test>
+  <test name="family" qual="all" compare="not_eq"><string>Iosevka Nerd Font Mono</string></test>
+  <edit name="family" mode="prepend_first" binding="strong"><string>Iosevka Nerd Font</string></edit>
+</match>
+```
+
+**The second test is load-bearing and not obvious.** fontconfig's system config appends the
+generic `monospace` family to the pattern of *any* monospaced font, so the first test alone
+also matches the terminals' explicit `Iosevka Nerd Font Mono` request and hijacks it back to
+the dual-width build — cells twice as wide as they should be. Skipping any pattern that
+already names Mono is what keeps the terminals intact.
+
+## Size is one knob for the whole desktop, not a terminal setting
+
+Omarchy drives shell text, GTK text and terminal text from a single number, and the terminal
+point size is **derived** from it:
+
+```sh
+omarchy display text size 15
+```
+
+That one command writes three things, anchored so that 12px is stock:
+
+| What | Where | How it's derived from 15px |
+| --- | --- | --- |
+| Shell base size | `~/.config/omarchy/shell.toml`, `[font] base-size` | the value itself — `15` |
+| Terminal point size | every terminal config that exists | `round(px × 9 / 12)` → **11** |
+| GTK text scaling | `org.gnome.desktop.interface text-scaling-factor` | quantised so the 11pt interface font lands whole → **1.2727** |
+
+**So don't write `11` anywhere.** It's today's worked example, the same way `36` is in
+[`cursor-size.md`](cursor-size.md); the value I actually hold is 15px, and the 9/12 anchor
+is Omarchy's to move. Setting a terminal's size by hand is how the three drift apart.
+
+`shell.toml` is the one file in `~/.config/omarchy/` that's a real override — absent by
+default, watched for changes, layered on top of the active theme so it survives theme
+switches. That's the opposite of `shell.json` next door in [`bar.md`](bar.md).
+
+## The family is the other command, and it has two traps
+
+```sh
+omarchy font set "Iosevka Nerd Font Mono"
+```
+
+It writes the family into all four terminal configs *and* regenerates
+`~/.config/fontconfig/fonts.conf`. Both traps are in that second half:
+
+- **It resets foot to size 9.** The size is hardcoded in the script — it rewrites foot's
+  whole `font=` line as `font=<family>:size=9` rather than editing the family in place. The
+  other three terminals keep their size. So running it undoes the size step, for one
+  terminal only, which is exactly the kind of half-change that reads as fine.
+- **It overwrites the Mono/non-Mono split above**, replacing `fonts.conf` with a plain
+  single-family version. The bar goes back to squeezed glyphs.
+
+So after ever running it: re-run `omarchy display text size 15`, and restore `fonts.conf`.
+The file carries a comment saying so; leave that comment there. On a machine that's already
+right, don't run it at all — the family is already in every config.
+
+## Which terminals
+
+Set the font in **every terminal config that exists**, and don't install a terminal in order
+to configure one. Those aren't the same test, and on this machine they disagree: only
+`foot` is installed, while all four configs are present because Omarchy ships copies of them
+regardless. Omarchy's own commands take the same line — they check for the file, not the
+binary — so three of these four files are correct and inert, ready if the terminal ever
+arrives.
+
+| Terminal | Config | Family line | Size line |
+| --- | --- | --- | --- |
+| foot *(installed here)* | `~/.config/foot/foot.ini` | `font=Iosevka Nerd Font Mono:size=11` | same line |
+| alacritty | `~/.config/alacritty/alacritty.toml` | `[font]` `normal`/`bold`/`italic` `family` | `size = 11` |
+| kitty | `~/.config/kitty/kitty.conf` | `font_family Iosevka Nerd Font Mono` | `font_size 11.0` |
+| ghostty | `~/.config/ghostty/config` | `font-family = "Iosevka Nerd Font Mono"` | `font-size = 11` |
+
+All four are **shipped copies**: Omarchy installs them with full default contents, so
+`omarchy refresh config foot/foot.ini` restores JetBrainsMono at 9. Nothing overrides them
+from outside, so the copy is where the value has to live — knowingly, and worth re-checking
+after a refresh.
+
+**A written config isn't a running terminal.** kitty and ghostty reload on a signal
+(`pkill -USR1 kitty`, `pkill -SIGUSR2 ghostty`) and Omarchy's commands send those for you.
+**foot has no reload signal at all** — a running foot keeps its startup font until it's
+closed, and only new windows pick the change up. `omarchy display text size` notices this and
+posts a notification saying to restart foot; that notification is the step telling you it
+isn't finished.
+
+## macOS
+
+The three cross-platform terminals read the **same paths** on macOS —
+`~/.config/ghostty/config`, `~/.config/kitty/kitty.conf`,
+`~/.config/alacritty/alacritty.toml` — so the family and size lines above transfer verbatim.
+What doesn't transfer is everything around them: no Omarchy ships or refreshes those files,
+so they're plain files I own outright, and there's no `omarchy display text size`, so the
+point size is written directly instead of derived. Terminal.app and iTerm are `defaults`
+keys and aren't captured; I don't use them.
+
+**The font package is the gotcha, and it's a real divergence, not a naming one.** The
+2026-06 Mac list has plain `font-iosevka`, which is *not* this font: no Nerd Font glyphs, and
+no family called `Iosevka Nerd Font Mono` for these configs to resolve. The Mac wants the
+patched build to match. Parked with the other Mac-blocked items in the map's fog.
+
+Not yet run on a Mac.
+
+## Knowing it's done
+
+**Omarchy.** One command reports all three halves of the size knob:
+
+```sh
+omarchy display text size
+# text size: 15 px
+# gtk text-scaling-factor: 1.2726999999999999
+# terminal font: 11 pt
+```
+
+The GTK factor prints with a float's worth of noise; it's the quantised `14/11`, not a value
+anyone typed.
+
+Then the family, per installed terminal — grep the config, since there's no command that
+reports it:
+
+```sh
+grep '^font=' ~/.config/foot/foot.ini    # font=Iosevka Nerd Font Mono:size=11
+```
+
+And the alias the bar resolves, which is the *other* family on purpose:
+
+```sh
+fc-match monospace          # IosevkaNerdFont-Regular.ttf: "Iosevka Nerd Font" "Regular"
+```
+
+**`omarchy font current` is the check that lies here.** It's `fc-match monospace` with the
+family extracted, so on this machine it prints `Iosevka Nerd Font` — correct for the bar,
+and wrong as a reading of what the terminals run. Anyone checking the terminal font with it
+sees a family no terminal is using and concludes the step failed. Read the terminal config
+for the terminal, and `fc-match` for the bar; they are supposed to differ by that one word.
+
+The other partial state: `omarchy display text size` reporting 11pt while the foot window
+you're reading it in is still drawing at the old size. That's the missing reload, not a
+failed write — open a new window.


### PR DESCRIPTION
Resolves #19.

Writes the seven remaining desktop steps — `input`, `bar`, `dock`, `sound`, `displays`, `idle-and-lock`, `terminal-font` — completing `steps/30-desktop/` and consuming the last of `pvinis/dotfiles`' `scripts/macos.sh` (`appearance.md` took 4 of its 11 settings; these take the other 7). Nothing on `hookers-green` needed changing: every value was already applied, so the work was stating the intents and building checks that can't be wrong. That's where the ticket's premise turned out to be half wrong, in the useful direction.

**Three of the seven "personal" values are Omarchy stock.** Bar position `top`, clock format `dddd HH:mm` and idle `150`/`300` are shipped defaults verbatim. The only thing that actually differs in `shell.json` is three third-party bar widgets, which the values-not-files rule excludes from being a step anyway. Same delta-mistaken-for-a-preference shape #12 found in `apps.md`; the steps state them as desired state regardless, per #8, and are honest no-ops here.

`input.md` is that story with a sharper edge: the intent is already true on Omarchy for **two different reasons**, and neither shows in a config diff. `natural_scroll = false` is Omarchy's explicit default; `tap-to-click` is *Hyprland's*, which nobody sets. `hyprctl getoption` prints a `set:` line that tells them apart — so the step checks that, and `set: false` is not a failure here.

**`shell.json` is a shipped copy with no override layer.** `omarchy refresh shell` copies stock back over it, and it carries its full default contents rather than a delta. Unlike #20's git config **there is no seam to find**: `~/.config/omarchy/shell.toml` *is* a genuine override file (absent by default, watched, user keys win) but carries only styling tokens, so bar position and idle timings have nowhere to live but the copy. What rescues it is that the values equal stock, which buys the same check #20 bought — `jq -S` diffing against stock and getting nothing means a refresh can't cost anything.

`monitors.lua` is the **only** hypr file with that same shape. Every other file in `~/.config/hypr/` is an all-commented template whose real defaults live in `default/hypr/` and load first, so a refresh costs you your overrides and nothing else. `monitors.lua` has no counterpart there and ships live values, so a refresh restores scale `2`/`auto`. Its `GDK_SCALE` also goes through `hl.env`, making it inert until the next login — the UWSM trap #6 found in `cursor-size.md`, now a second occurrence rather than a one-off.

**The terminal font has no size of its own.** The ticket listed "Iosevka at 11 across four files" and "shell base-size 15" as two things; they're one knob. `omarchy display text size 15` drives shell base-size, the GTK scaling factor and the terminal point size together (`round(px × 9/12)` = 11), so 11 is derived and must not be frozen.

**Decisions in the steps**

- **Two font families are deliberate** — terminals pin `Iosevka Nerd Font Mono` for single-cell metrics, while the `monospace` alias resolves to the dual-width build so the bar gets full-size glyphs. The `not_eq` test in `fonts.conf` is load-bearing: without it the rule hijacks the terminals' own request
- **`omarchy font set` undoes both halves of that** — hardcodes foot back to `size=9` and overwrites `fonts.conf` — and **`omarchy font current` lies about the terminals**, since it reads the alias and reports the bar's family
- **Configure every terminal config that exists, don't install a terminal to configure one.** Only `foot` is installed here; all four configs ship regardless, and Omarchy's own commands test for the file, not the binary
- **`displays.md` asks and does not assert** (#3) — scale is per-panel. It also carries the *which display is primary* ask, unasked here since there's one panel; both routed to it by #13
- **`dock.md` and `sound.md` are macOS-only**, which is the one-`##`-section applicability mechanism working as `steps/README.md` predicted, not a gap
- **`idle-and-lock.md`'s macOS half is left unwritten rather than invented** — those keys moved to System Settings > Lock Screen and were never captured. The section declares the step applies there and says how to capture it; it joins the Mac-blocked items already in the map's fog

Two things found only by running commands rather than reading them: the `omarchy bar` commands are value-idempotent but **not byte-idempotent** (each pipes the file through a key-sorting `jq` pass), and **`omarchy toggle idle` is the check that lies** for idle timings — it drops a marker outside `shell.json`, and while it exists the numbers are right and nothing idles.

macOS values are captured from `scripts/macos.sh`; the notes around them are reasoned and not re-run on a Mac.

Full reasoning in the resolution on #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
