### PR TITLE
steps: the chain of trust ends at 1Password, not at a pile of keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ Steps live in `steps/`; the format they follow is [`steps/README.md`](steps/READ
 
 - [`1password-signin.md`](steps/00-human/1password-signin.md) — the root of trust
 - [`app-store-signin.md`](steps/00-human/app-store-signin.md) — macOS; gates the App Store half of the apps step
+- [`gh-auth.md`](steps/00-human/gh-auth.md) — GitHub over HTTPS; no ssh key and no signing key, decided in [#5](https://github.com/pvinis/setup/issues/5)
 - *app logins* — Beeper, browser, Obsidian: [#21](https://github.com/pvinis/setup/issues/21)
-- *ssh key, gpg key, `gh auth login`* — [#5](https://github.com/pvinis/setup/issues/5)
 
 **`10-system/`**
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,3 +55,18 @@ What I want present, stated without reference to what any one platform ships —
 free to be a no-op where the platform already provides it. The opposite of a delta against a
 particular machine.
 _Avoid_: manifest, delta, diff
+
+### Identity and secrets
+
+**Root of trust**:
+1Password, signed in, with `op` able to reach the vault. Every later secret depends on this
+one thing and nothing depends on anything before it, which is what makes it the root rather
+than the first item on a list. Reaching it is irreducibly human — an account password and a
+second factor — so it is a human step and it is walked first.
+_Avoid_: secret store, vault, password manager (those name the product; this names its role)
+
+**The rule:** the runbook delivers *access* to secrets, never copies of them. A step that
+needs a secret reads it when it needs it, addressed as `op://Vault/Item/field`; nothing is
+fetched ahead of time, restored from a list, or written into a file this repo manages. A
+"decrypt these files onto the new machine" inventory is the dotfiles problem wearing a
+security hat, and it is out of scope for the same reason everything else there is.

--- a/reference/mac-snapshot-2026-06/README.md
+++ b/reference/mac-snapshot-2026-06/README.md
@@ -19,12 +19,13 @@ exactly why it isn't treated as truth:
 | git config path | `~/.gitconfig` | `~/.config/git/config` (XDG) |
 | `init.defaultBranch` | `main` | `master` |
 | aliases | one set | a different set |
-| `commit.gpgsign` | on, with a hardcoded signing key | absent |
-| `gh` credential helper | — | hardcoded absolute mise install path |
+| `commit.gpgsign` | on, with a hardcoded signing key | absent — **settled: absent is intended**, [#5](https://github.com/pvinis/setup/issues/5) |
+| `gh` credential helper | — | was a hardcoded absolute mise install path; **settled and repaired**, [#5](https://github.com/pvinis/setup/issues/5) |
 | mise config | Mac tool set | diverges |
 
 Which side of each divergence is the *intended* state is an open question for the runbook, not
-something this directory answers.
+something this directory answers — though the rows marked **settled** above have since been
+answered elsewhere, and the Mac's side lost both times.
 
 ## What's here
 
@@ -39,7 +40,10 @@ something this directory answers.
 ## Deliberately NOT captured
 
 - **`~/.config/gh/hosts.yml`** — holds the GitHub auth token. Secret. Git-ignored. Recreate on a
-  new machine with `gh auth login`.
+  new machine with `gh auth login`. **Not true on a keyring machine**: on `hookers-green` the
+  token is in gnome-keyring and this file is 80 bytes of `git_protocol` and a username, with no
+  secret in it at all ([#5](https://github.com/pvinis/setup/issues/5)). The "recreate with
+  `gh auth login`" advice still holds; the "it's secret" premise doesn't.
 - **neovim** — no `~/.config/nvim` existed on that machine.
 - **zoxide / fzf / direnv** — no standalone config; wired up via shell init, which lives in the fish
   config.

--- a/steps/00-human/1password-signin.md
+++ b/steps/00-human/1password-signin.md
@@ -19,6 +19,29 @@ I can't do this part — GUI app, account password, second factor.
 Then re-run the check below. The work account is a separate sign-in — ask whether this
 machine needs it, don't assume either way.
 
+## How a later step asks for a secret
+
+Nothing is fetched here. This step's whole output is *access* — after it, any later step that
+needs a secret reads it at the moment it needs it, addressed as a single readable path:
+
+```
+op://Private/<item>/<field>
+```
+
+That form is the one thing worth keeping from the older repos, and what rotted tells you why.
+`pvinis/dotfiles` went through three generations: git-crypt, then opaque item uuids, then
+this. The uuid generation is the one that broke — stale references were indistinguishable
+from working ones on sight, and some copies silently rendered literal garbage into files
+rather than failing. A readable vault/item/field path can be eyeballed by a human or an agent
+and found wrong.
+
+**No secret is ever copied into this repo or into a file the runbook manages**, and there is
+no restore list. The git-crypt era kept an inventory of files to decrypt onto a new machine
+(`~/.npmrc`, `~/.aws/credentials`, `~/.config/hub`, an `.ask/` directory); none of them exist
+on this machine, and each is a file whose value *is* its contents, which
+[`../README.md`](../README.md) puts outside what a step can carry. So the chain of trust
+stops here, at the vault being readable.
+
 ## Knowing it's done
 
 ```sh
@@ -32,3 +55,22 @@ mean opposite things:
   locked, or the CLI integration is off. Ask for an unlock; don't reinstall anything.
 - **`op account list` prints nothing** — the CLI has never been told about the account at
   all. That's the real never-ran state.
+
+`op whoami` alone is the convenient proxy, not the authoritative source, and everything
+downstream now hangs off this one check — it can pass while a read still fails, because being
+signed in and having the vault shared to *this* account are different things. So prove the
+vault is actually reachable:
+
+```sh
+op vault list
+```
+
+`Private` in the output means a later `op://Private/...` read has somewhere to resolve
+against. That's a real authenticated call rather than a look at local session state.
+
+Deliberately no named item here. A stronger canary would read one known field, but this repo
+is public and the item titles are themselves worth not publishing — the same reason the work
+tenant name came out of this file in
+[#10](https://github.com/pvinis/setup/issues/10). Vault-level is as far as a public step
+should go; if a read fails after this passes, it's a sharing problem on one item, and the
+error says so.

--- a/steps/00-human/gh-auth.md
+++ b/steps/00-human/gh-auth.md
@@ -1,0 +1,108 @@
+# Sign in to GitHub
+
+`gh` authenticated as **pvinis**, and git able to push over HTTPS without asking anyone for a
+password. Everything this machine does with GitHub goes through that one token — there is no
+SSH key and no signing key, deliberately (see below).
+
+Needs `gh`, from [`../20-packages/cli-tools.md`](../20-packages/cli-tools.md). Needs nothing
+else: `pvinis/setup` is public, so the clone that got you here required no credential at all.
+
+## Hand it to Pavlos
+
+Human end to end — a browser, an account password, a second factor. The agent can start the
+command, but it cannot finish it, so this is a `00-human/` step rather than a step with a
+human beat in it.
+
+> Run `gh auth login`. Choose **GitHub.com**, **HTTPS**, and **authenticate in a browser**.
+> It prints a one-time code — paste that into the browser page it opens, sign in, and
+> authorise. Tell me when it's done.
+
+Take the HTTPS option rather than SSH on purpose. This account has **no SSH keys registered
+at all**, which is ten years of not needing one rather than an oversight, so the runbook
+doesn't create one either.
+
+## Repair the credential helper
+
+`gh auth login` writes a credential helper into `~/.gitconfig` and writes it **wrong** — not
+as a mistake you made, but as what the tool does when `gh` is mise-managed. It resolves `gh`
+to a real path at the moment it runs:
+
+```
+[credential "https://github.com"]
+	helper = 
+	helper = !/home/pavlos/.local/share/mise/installs/gh/2.97.0/gh_2.97.0_linux_amd64/bin/gh auth git-credential
+```
+
+That absolute path points into a **versioned** install directory. The next `gh` upgrade moves
+the binary out from under it and git silently loses its helper on every push — silently
+because git treats a helper that fails to run as a helper with nothing to say, so you get a
+username prompt instead of an error naming the cause.
+
+So the step's job is to *correct* what the previous command just wrote, on every machine.
+The fix is `!gh auth git-credential` — PATH-resolved, so it survives any version of `gh` in
+any install location. Applied to both blocks, because `gh` writes `gist.github.com`
+separately and it breaks the same way:
+
+```sh
+for host in github.com gist.github.com; do
+  git config --global --unset-all "credential.https://$host.helper" '/' 2>/dev/null
+  git config --global --get-all "credential.https://$host.helper" 2>/dev/null \
+    | grep -qxF '!gh auth git-credential' \
+    || git config --global --add "credential.https://$host.helper" '!gh auth git-credential'
+done
+```
+
+**Leave the empty `helper = ` line above each one alone.** It isn't leftover junk — an empty
+value is git's reset directive, clearing helpers inherited from earlier config files.
+Dropping it changes which helpers run.
+
+That's why the loop is shaped the way it is, and it's worth knowing why the two obvious
+one-liners are both wrong, because both *look* like they work:
+
+- **`--replace-all … '!/.*'`** — a value-pattern starting with `!` is git's **negation**
+  operator, not a literal. It inverts to "values without a slash", which is the reset line,
+  so it overwrites the reset directive and leaves the broken helper untouched. The exact
+  opposite of the intent, and the config still looks plausible afterwards.
+- **`--replace-all … '/'`** — correct the first time, then **adds a duplicate every time it
+  finds nothing to replace**. Three runs of the step, three helpers. Steps get re-run, so
+  that's a real outcome, not a hypothetical.
+
+Hence: unset what matches, then add only if it isn't already there. Unsetting a pattern that
+matches nothing exits non-zero and changes nothing, which is why it's swallowed.
+
+## Knowing it's done
+
+```sh
+gh auth status
+```
+
+Reports the account, the protocol, and where the token lives. The never-ran state is
+`You are not logged into any GitHub hosts`.
+
+**The token is not in a file**, which matters when you go looking for it. On this machine
+`gh auth status` reports it in the **keyring** (gnome-keyring here, Keychain on macOS) and
+`~/.config/gh/hosts.yml` is 80 bytes of `git_protocol` and a username — no secret in it. The
+2026-06 Mac snapshot calls that file secret and git-ignores it on that basis; on a keyring
+machine that's simply not true any more.
+
+Then prove the helper repair took, which is the check that can actually fail later:
+
+```sh
+git config --get-all credential.https://github.com.helper
+```
+
+Expect a blank line (the reset) then `!gh auth git-credential`. **Any absolute path in that
+output is the defect back**, whether or not pushing works today — it works right up until the
+next `gh` upgrade, so a passing push is not evidence.
+
+The end-to-end check is a push to any repo you can write to; there's nothing to configure for
+it beyond the above.
+
+## Scopes
+
+The login asks for what `gh` itself needs and the runbook adds nothing: `gist`, `read:org`,
+`repo`, `workflow`. Notably **absent** are `admin:public_key`, `admin:gpg_key` and
+`admin:ssh_signing_key` — a token that can register keys on the account is a token that can
+grant a machine's access, and nothing in the runbook registers keys, so it doesn't ask for
+the ability to. If you ever need one for a one-off, `gh auth refresh -h github.com -s <scope>`
+adds it for that job rather than baking it into every machine.

--- a/steps/40-shell/git-config.md
+++ b/steps/40-shell/git-config.md
@@ -5,9 +5,20 @@ conflict resolutions remembered, `main` for new repos, and one alias of my own. 
 desired-state idea as the package steps — state what I want, and let it be a no-op wherever
 the platform already provides it.
 
-**Identity is not this step.** Name, email, signing key and the credential helper belong to
-the chain of trust in [#5](https://github.com/pvinis/setup/issues/5). They land in the same
-file this step establishes, which is why the seam below is worth getting right first.
+**Identity is two rows of the table below**, and not a step of its own. Name and email are
+values I can state and check like any other, and neither is a secret; they land in the same
+file the seam below establishes, which is why getting that seam right comes first. The
+credential helper is *not* here — `gh auth login` writes it, so
+[`../00-human/gh-auth.md`](../00-human/gh-auth.md) owns repairing it.
+
+**Commits are not signed, and that's a decision.** The 2026-06 Mac signed with a hardcoded
+GPG key; this machine never has, and every commit in this repo is unsigned. The runbook
+records the negative rather than leaving the positive to be assumed again — no signing key,
+no `commit.gpgsign`, nothing to import, and nothing anywhere in the chain of trust waiting on
+gpg. (The GitHub account still carries 13 unrevoked GPG keys from years of per-machine keys.
+Pruning them is account hygiene, not something you do on a new machine, so it isn't here.)
+
+Both settled in [#5](https://github.com/pvinis/setup/issues/5).
 
 Needs git, from [`../20-packages/cli-tools.md`](../20-packages/cli-tools.md).
 
@@ -33,11 +44,13 @@ looked like a divergence to resolve. It isn't. They're two layers, and the perso
 
 ## What I want
 
-Written to `~/.gitconfig` on macOS; on Omarchy all but the first two arrive stock, so read
-them back rather than writing them again.
+Written to `~/.gitconfig` on macOS; on Omarchy all but the first three arrive stock, so read
+them back rather than writing them again. Identity is in the first three for the obvious
+reason — no platform ships it.
 
 | What I want | Setting |
 | --- | --- |
+| commits attributed to me | `user.name = Pavlos Vinieratos`, `user.email = pvinis@gmail.com` |
 | `main` for new repos | `init.defaultBranch = main` |
 | undo the last commit, keep the changes staged | `alias.boc = reset --soft HEAD~1` |
 | rebase on pull, never a merge bubble | `pull.rebase = true` |
@@ -61,15 +74,17 @@ Omarchy ships `/usr/share/omarchy/config/git/config` and **copies** it to
 `.bak.<epoch>` beside it). So personal values written there sit in the path of the next
 refresh, and stock improvements never reach a file you've edited.
 
-The whole Omarchy job is therefore: put the two personal settings in `~/.gitconfig`, and
-leave the copy **exactly as shipped**.
+The whole Omarchy job is therefore: put the personal settings in `~/.gitconfig`, and leave
+the copy **exactly as shipped**.
 
 ```sh
+git config --global user.name 'Pavlos Vinieratos'
+git config --global user.email 'pvinis@gmail.com'
 git config --global init.defaultBranch main
 git config --global alias.boc 'reset --soft HEAD~1'
 ```
 
-Both land in `~/.gitconfig` — but only once it exists, so create it first (an empty
+They all land in `~/.gitconfig` — but only once it exists, so create it first (an empty
 `touch ~/.gitconfig` is enough) or write the file directly. On a machine where `--global`
 has already been run without it, the values are in the copy and need moving out, not just
 setting.
@@ -105,9 +120,15 @@ inventing state; this section is here so the next one has a shape to arrive into
 ## Knowing it's done
 
 ```sh
+git config --get user.email                  # pvinis@gmail.com
 git config --get init.defaultBranch          # main
 git config --get-regexp '^alias\.'           # boc, plus whatever the platform ships
+git config --get commit.gpgsign              # nothing, and that's the intended state
 ```
+
+The `gpgsign` line is the one whose *empty* output is the pass. An unset value here means
+unsigned commits, which is what was decided; if it ever comes back set, something restored a
+config from the Mac era.
 
 On Omarchy there's a second check, and it's the one that proves the seam holds:
 


### PR DESCRIPTION
Resolves [#5](https://github.com/pvinis/setup/issues/5).

The ticket's premise was that a fresh machine is stuck in a chain of dependent secrets — no signed commits without the GPG key, no GPG key without 1Password, no 1Password without a browser. Two of those three links turned out not to exist.

**No commit signing.** The Mac signed with a hardcoded `57EBE37FEAE59ADD`; this machine never has, and every commit in this repo is unsigned. The account carries **13 unrevoked GPG keys** from years of per-machine keys nobody ever pruned — which is what the habit actually produced. Recorded as a negative, per #12's rule for positives that were previously assumed.

**No SSH key.** No `~/.ssh` on this machine and **zero** SSH keys on the account, auth or signing. Everything goes over HTTPS through the `gh` credential helper and always has.

So the chain is one link long: 1Password → everything else.

## Changes

- **New `steps/00-human/gh-auth.md`** — `gh auth login` is human end to end, so it's a `00-human/` step rather than a step with a human beat. Owns repairing the credential helper.
- **`git-config.md`** — absorbs name/email as table rows, drops its deferral paragraph, records the no-signing negative and a verify whose *empty* output is the pass.
- **`1password-signin.md`** — gains the `op://Vault/Item/field` addressing form (the one thing worth salvaging from `dotfiles`, and why the uuid generations rotted) and a vault-reachability check, since `op whoami` can pass while a read still fails.
- **`CONTEXT.md`** — gains **Root of trust**, and the rule that falls out of it: the runbook delivers *access* to secrets, never copies of them.
- **`AGENTS.md`**, **snapshot README** — catalogue entry; two of the snapshot's open divergences are now closed.

## The credential-helper fix is not the obvious one

`gh auth login` writes an absolute path into a *versioned* mise install dir, so the next `gh` upgrade silently kills it. Both one-liners you'd reach for are wrong, and both look like they work:

- `--replace-all … '!/.*'` — a value-pattern starting with `!` is git's **negation** operator. It inverts to "values without a slash", which is the empty reset directive, so it overwrites the reset line and leaves the broken helper in place.
- `--replace-all … '/'` — right the first time, then **adds a duplicate every run that finds nothing to replace**. Steps get re-run; three runs, three helpers.

Both verified in a scratch config. The step uses unset-matching-then-add-if-absent, which is idempotent across runs. Applied on `hookers-green` (backup at `~/.gitconfig.bak.<epoch>`); this PR's own push exercised the repaired helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)